### PR TITLE
2a/v2: Add data on risk categories

### DIFF
--- a/app/data/risks.js
+++ b/app/data/risks.js
@@ -1,0 +1,221 @@
+
+const riskCategories = {
+	'Health needs': {
+		'Communication needs': {
+			'Need and severity': {},
+			'Info on independent living': {},
+			'Support they have / will require': {},
+		},
+		'Learning difficulties': {
+			'Need and effect on everyday life': {},
+			'Medication / treatment': {},
+		},
+		'Mobility needs': {
+			'Need and effect on everyday life': {},
+			'Ability to use stairs': {},
+			'Medication / treatment': {},
+		},
+		'Epilepsy': {
+			'Frequency / recency of seizures': {},
+			'When seizures typically occur (day, night, both)': {},
+			'Medication / treatment': {},
+		}
+	},
+	'Risk to self': {
+		"Substance or alcohol abuse": {
+			"Substances misused and methods": {},
+			"Amount of consumption": {},
+			"Medication / treatment": {},
+			"Engagement with support whilst in custody": {},
+			"Referral for community support": {},
+		},
+		"Mental health": {
+			"Need, severity, and effect on everyday life": {},
+			"Status of clinical diagnosis": {},
+			"Ability to live independently / in shared accomodation": {},
+			"Medication / treatment": {},
+			"Engagement with support whilst in custody": {},
+			"Referral for community support": {},
+		},
+		"Self-harm and suicide": {
+			"Details of incidents (treatment required, methods)": {},
+			"Current concerns": {},
+			"Details of ACCT history (when opened/closed, reasons)": {},
+			"Referral for community support": {},
+		},
+		"Exploitation (risk to self)": {
+			"Known perpatrator(s)": {},
+			"Nature of exploitation": {},
+			"Safeguarding measures / restraining orders": {},
+			"Areas to avoid": {},
+
+		},
+		"Domestic violence (victim)": {
+			"Known perpatrator(s)": {},
+			"Details of incidents": {},
+			"Safeguarding measures / restraining orders": {},
+			"Areas to avoid": {},
+		},
+		"Sex work": {
+			"Details of incidents": {},
+			"Risk in community": {},
+			"Safeguarding measures / restraining orders": {},
+			"Areas to avoid": {},
+			"Support they have / will require": {},
+		},
+		"Media interest": {
+			"Current concerns": {},
+			"Areas to avoid": {},
+		},
+		"Isolation": {
+			"Current concerns": {},
+			"Safeguarding measures / restraining orders": {},
+			"Areas to avoid": {},
+			"Support they have / will require": {},
+		}
+	},
+	'Risk of serious harm': {
+		'Exploitation (risk to others)': {
+			'Specific risk to others': {
+				'Known victim(s)': {},
+				'Public': {},
+				'Shared accommodation residents': {},
+			},
+			'Nature of exploitation': {},
+			'Safeguarding measures / Restraining orders': {},
+			'Areas to avoid': {},
+		},
+		'Domestic violence (perpatrator)': {
+			'Specific risk to others': {
+				'Known victim(s)': {},
+				'Ex- or future partners': {},
+				'Family members': {},
+			},
+			'Details of incidents': {},
+			'Safeguarding measures / Restraining orders': {},
+			'Areas to avoid': {},
+		},
+		'Gang involvement': {
+			'Specific risk to others': {
+				'Staff': {},
+				'Public': {},
+				'Shared accommodation residents': {},
+			},
+			'Gang details: name, areas and/or rivals': {},
+			'Safeguarding measures / Restraining orders': {},
+			'Areas to avoid': {},
+		},
+		'Violent offences': {
+			'Specific risk to others': {
+				'Known victim(s)': {},
+				'Public': {},
+				'Shared accommodation residents': {},
+				'Staff': {},
+			},
+			'Details of incidents': {},
+			'Safeguarding measures / Restraining orders': {},
+			'Name, relationship or location of victims': {},
+		},
+		'Drug supply offences': {
+			'Specific risk to others': {
+				'Applicant': {},
+				'Public': {},
+				'Drug users': {},
+				'Shared accommodation residents': {},
+			},
+			'Details of incidents': {},
+			'County lines involvement': {},
+			'Safeguarding measures / Restraining orders': {},
+			'Areas to avoid': {},
+		},
+		'Hate-related attitudes': {
+			'Specific risk to others': {
+				'Public': {},
+				'Known victim(s)': {},
+				'Staff': {},
+				'Residents': {},
+				'Ethnic minorities': {},
+				'Religious groups': {},
+				'LGBTQ+ community': {},
+				'Women': {},
+			},
+			'Details of incidents': {},
+			'Cell-sharing risk assessment (CSRA)': {},
+		},
+		'Acquisitive offending': {
+			'Specific risk to others': {
+				'Public': {},
+				'Homeowners': {},
+				'Shop owners / staff': {},
+			},
+			'Details of incidents': {},
+			'Safeguarding measures / Restraining orders': {},
+			'Areas to avoid': {},
+		},
+		'Cuckooing': {
+			'Specific risk to others': {
+				'Known victim(s)': {},
+				'Public': {},
+				'Shared accomodation residents': {},
+				'Drug users': {},
+			},
+			'Details of incidents': {},
+		},
+		'Financial abuse or fraud': {
+			'Specific risk to others': {
+				"Known victim(s)": {},
+				"Vulnerable adults": {},
+				"Shared accomodation residents": {},
+				"Ex- or future partners": {},
+				"Family members": {},
+			},
+			'Details of incidents': {},
+			'Safeguarding measures / Restraining orders': {},
+			'Areas to avoid': {},
+		},
+		'Arson': {
+			'Specific risk to others': {
+				"Known victim(s)": {},
+				"Public": {},
+				"Shared accomodation residents ": {},
+				"Staff": {},
+				"Ex- or future partners": {},
+				"Family members": {},
+			},
+			'Details of incidents': {},
+			'Safeguarding measures / Restraining orders': {},
+			'Areas to avoid': {},
+		},
+		'Weapons': {
+			'Specific risk to others': {
+				'Public': {},
+				'Shared accomodation residents': {},
+				'Staff': {},
+			},
+			'Details of incidents': {},
+		},
+		'Risk to staff': {
+			"Specific risk to others": {
+				"Staff": {},
+				"Probation worker": {},
+				"Other": {},
+			},
+			"Details of incidents": {},
+			"If incidents occurred in supported accomodation": {},
+			"License / Bail conditions": {},
+			"Safeguarding measures / restraining orders": {},
+			"Areas to avoid": {},
+		},
+		'Risk to property / criminal damage': {
+			"Specific risk to others": {
+				"Staff": {},
+				"Public": {},
+				"Shared accomodation residents": {},
+			},
+			"Details of incidents": {},
+			"If incidents occurred in supported accomodation": {},
+		},
+	}
+}
+
+module.exports = riskCategories

--- a/app/filters.js
+++ b/app/filters.js
@@ -5,15 +5,24 @@
 
 const govukPrototypeKit = require('govuk-prototype-kit')
 const addFilter = govukPrototypeKit.views.addFilter
-
+const addFunction = govukPrototypeKit.views.addFunction
+const riskCategories = require('./data/risks')
 
 addFilter('cleanArray', (array) => {
 	return array.filter(item => {
-		return (item && (item !==""))
+		return (item && (item !== ""))
 	})
 })
 
 addFilter('push', (array, item) => {
 	array.push(item)
 	return array
+})
+
+addFunction('slugify', (string) => {
+	return string.toLowerCase().replaceAll(/\W/g, '-')
+})
+
+addFunction('riskCategories', () => {
+	return riskCategories
 })

--- a/app/views/2a/v2/_routes.js
+++ b/app/views/2a/v2/_routes.js
@@ -1,7 +1,8 @@
 const govukPrototypeKit = require('govuk-prototype-kit')
 const router = govukPrototypeKit.requests.setupRouter()
+const riskCategories = require('../../../data/risks')
 
-router.get('*', function(req, res, next){
+router.get('*', function (req, res, next) {
 	// Change the service name for this whole feature
 	res.locals['serviceName'] = 'Short-Term Accommodation (CAS-2) Bail'
 
@@ -32,15 +33,22 @@ router.post('/fei/info-needed', (req, res, next) => {
 })
 
 router.post('/fei/info-needed--details', (req, res, next) => {
-	let question = req.session.data['health-needs']
-
-	if (question) {
-		if (question.includes('Communication needs') || question.includes('Learning difficulties / disabilities')  || question.includes('Mobility needs') || question.includes('Epilepsy')) {
-			res.redirect('info-needed--context');
+	console.log(req.session.data)
+	const hasContext = Object.keys(riskCategories).find(category => {
+		const slug = category.toLowerCase().replaceAll(/\W/g, '-')
+		const question = req.session.data[slug];
+		if (question) {
+			return Object.keys(riskCategories[category]).find(risk => question.includes(risk)) !== undefined;
 		} else {
-			res.redirect('note');
+			return false;
 		}
-	} else { next() }
+	})
+
+	if (hasContext !== undefined) {
+		res.redirect('info-needed--context');
+	} else {
+		res.redirect('note');
+	}
 })
 
 router.post('/fei/info-needed--context', (req, res, next) => {

--- a/app/views/2a/v2/fei/info-needed--context.html
+++ b/app/views/2a/v2/fei/info-needed--context.html
@@ -32,266 +32,57 @@
 		}
 	}) %}
 
-		{% if data['health-needs'] %}
-			{% if data['health-needs'].includes('Communication needs') %}
-				{{ govukCheckboxes({
-					idPrefix: 'communication-needs',
-					name: 'communication-needs',
-					fieldset: {
-						legend: {
-							html: 'Communication needs',
-							classes: 'govuk-fieldset__legend--m'
-						}
-					},
-					items: [
-						{
-							html: 'Need and severity',
-							value: 'Need and severity',
-							checked: checked('communication-needs','Need and severity'),
-							conditional: {
-								html: noteBox
-							}
-						},
-						{
-							html: 'Info on independent living',
-							value: 'Info on independent living',
-							checked: checked('communication-needs','Info on independent living'),
-							conditional: {
-								html: noteBox
-							}
-						},
-						{
-							html: 'Support they have / will require',
-							value: 'Support they have / will require',
-							checked: checked('communication-needs','Support they have / will require'),
-							conditional: {
-								html: noteBox
-							}
-						}
-					]
-				}) }}
+		{% for category, subcategories in riskCategories() %}
+			{% if data[slugify(category)] %}
+				{% for subcategory, info_types in subcategories %}
+					{% if data[slugify(category)].includes(subcategory) %}
+						{% set items = [] %}
+						{% for info_type, details in info_types %}
+							{% set conditional = noteBox %}
+							{% set detail_length = details | length %}
+							{% if detail_length > 0 %}
+								{% set more = [] %}
+								{% for detail, empty in details %}
+									{% set more = more | push({
+										html: detail,
+										value: detail
+									}) %}
+								{% endfor %}
+								{% set conditional = govukCheckboxes({
+									idPrefix: [slugify(subcategory), slugify(info_type)].join('-'),
+									name: [slugify(subcategory), slugify(info_type)].join('-'),
+									items: more,
+									formGroup: {
+										afterInputs: {html: noteBox}
+									}
+								}) %}
+							{% endif %}
+
+							{% set items = items | push({
+								html: info_type,
+								value: info_type,
+								checked: checked(slugify(subcategory), info_type),
+								conditional: {
+									html: conditional
+								}
+							}) %}
+						{% endfor %}
+
+						{{ govukCheckboxes({
+							idPrefix: slugify(subcategory),
+							name: slugify(subcategory),
+							fieldset: {
+								legend: {
+									html: subcategory,
+									classes: 'govuk-fieldset__legend--m'
+								}
+							},
+							items: items
+						}) }}
+					{% endif %}
+				{% endfor %}
 			{% endif %}
-
-			{% if data['health-needs'].includes('Learning difficulties / disabilities') %}
-				{{ govukCheckboxes({
-					idPrefix: 'learning-difficulties',
-					name: 'learning-difficulties',
-					fieldset: {
-						legend: {
-							html: 'Learning difficulties / disabilities',
-							classes: 'govuk-fieldset__legend--m'
-						}
-					},
-					items: [
-						{
-							html: 'Need and effect on everyday life',
-							value: 'Need and effect on everyday life',
-							checked: checked('learning-difficulties','Need and effect on everyday life'),
-							conditional: {
-								html: noteBox
-							}
-						},
-						{
-							html: 'Medication / treatment',
-							value: 'Medication / treatment',
-							checked: checked('learning-difficulties','Medication / treatment'),
-							conditional: {
-								html: noteBox
-							}
-						}
-					]
-				}) }}
-			{% endif %}
-
-			{% if data['health-needs'].includes('Mobility needs') %}
-				{{ govukCheckboxes({
-					idPrefix: 'mobility-needs',
-					name: 'mobility-needs',
-					fieldset: {
-						legend: {
-							html: 'Mobility needs',
-							classes: 'govuk-fieldset__legend--m'
-						}
-					},
-					items: [
-						{
-							html: 'Need and effect on everyday life',
-							value: 'Need and effect on everyday life',
-							checked: checked('mobility-needs','Need and effect on everyday life'),
-							conditional: {
-								html: noteBox
-							}
-						},
-						{
-							html: 'Ability to use stairs',
-							value: 'Ability to use stairs',
-							checked: checked('mobility-needs','Ability to use stairs'),
-							conditional: {
-								html: noteBox
-							}
-						},
-						{
-							html: 'Medication / treatment',
-							value: 'Medication / treatment',
-							checked: checked('mobility-needs','Medication / treatment'),
-							conditional: {
-								html: noteBox
-							}
-						}
-					]
-				}) }}
-			{% endif %}
-
-			{% if data['health-needs'].includes('Epilepsy') %}
-				{{ govukCheckboxes({
-					idPrefix: 'epilepsy',
-					name: 'epilepsy',
-					fieldset: {
-						legend: {
-							html: 'Epilepsy',
-							classes: 'govuk-fieldset__legend--m'
-						}
-					},
-					items: [
-						{
-							html: 'Frequency / recency of seizures',
-							value: 'Frequency / recency of seizures',
-							checked: checked('epilepsy','Frequency / recency of seizures')
-						},
-						{
-							html: 'When seizures typically occur (day, night, both)',
-							value: 'When seizures typically occur (day, night, both)',
-							checked: checked('epilepsy','When seizures typically occur (day, night, both)')
-						},
-						{
-							html: 'Medication / treatment',
-							value: 'Medication / treatment',
-							checked: checked('epilepsy','Medication / treatment')
-						}
-					]
-				}) }}
-			{% endif %}
-		{% endif %}
-
-
-
-		{# {% if data['risk-of-serious-harm'] %}
-			{% if data['risk-of-serious-harm'].includes('Exploitation (risk to others)') %}
-				{{ govukCheckboxes({
-					idPrefix: 'exploitation',
-					name: 'exploitation',
-					fieldset: {
-						legend: {
-							html: 'Substance or alcohol abuse',
-							classes: 'govuk-fieldset__legend--m'
-						}
-					},
-					items: [
-						{
-							html: 'Need and severity',
-							value: 'Need and severity',
-							checked: checked('exploitation','Need and severity')
-						},
-						{
-							html: 'Info on independent living',
-							value: 'Info on independent living',
-							checked: checked('exploitation','Info on independent living')
-						},
-						{
-							html: 'Support they have / will require',
-							value: 'Support they have / will require',
-							checked: checked('exploitation','Support they have / will require')
-						}
-					]
-				}) }}
-			{% endif %}
-
-			{% if data['risk-of-serious-harm'].includes('Learning difficulties / disabilities') %}
-				{{ govukCheckboxes({
-					idPrefix: 'learning-difficulties',
-					name: 'learning-difficulties',
-					fieldset: {
-						legend: {
-							html: 'Learning difficulties / disabilities',
-							classes: 'govuk-fieldset__legend--m'
-						}
-					},
-					items: [
-						{
-							html: 'Need and effect on everyday life',
-							value: 'Need and effect on everyday life',
-							checked: checked('learning-difficulties','Need and effect on everyday life')
-						},
-						{
-							html: 'Medication / treatment',
-							value: 'Medication / treatment',
-							checked: checked('learning-difficulties','Medication / treatment')
-						}
-					]
-				}) }}
-			{% endif %}
-
-			{% if data['risk-of-serious-harm'].includes('Mobility needs') %}
-				{{ govukCheckboxes({
-					idPrefix: 'mobility-needs',
-					name: 'mobility-needs',
-					fieldset: {
-						legend: {
-							html: 'Mobility needs',
-							classes: 'govuk-fieldset__legend--m'
-						}
-					},
-					items: [
-						{
-							html: 'Need and effect on everyday life',
-							value: 'Need and effect on everyday life',
-							checked: checked('mobility-needs','Need and effect on everyday life')
-						},
-						{
-							html: 'Ability to use stairs',
-							value: 'Ability to use stairs',
-							checked: checked('mobility-needs','Ability to use stairs')
-						},
-						{
-							html: 'Medication / treatment',
-							value: 'Medication / treatment',
-							checked: checked('communication-needs','Medication / treatment')
-						}
-					]
-				}) }}
-			{% endif %}
-
-			{% if data['risk-of-serious-harm'].includes('Epilepsy') %}
-				{{ govukCheckboxes({
-					idPrefix: 'epilepsy',
-					name: 'epilepsy',
-					fieldset: {
-						legend: {
-							html: 'Epilepsy',
-							classes: 'govuk-fieldset__legend--m'
-						}
-					},
-					items: [
-						{
-							html: 'Frequency / recency of seizures',
-							value: 'Frequency / recency of seizures',
-							checked: checked('epilepsy','Frequency / recency of seizures')
-						},
-						{
-							html: 'When seizures typically occur (day, night, both)',
-							value: 'When seizures typically occur (day, night, both)',
-							checked: checked('epilepsy','When seizures typically occur (day, night, both)')
-						},
-						{
-							html: 'Medication / treatment',
-							value: 'Medication / treatment',
-							checked: checked('epilepsy','Medication / treatment')
-						}
-					]
-				}) }}
-			{% endif %}
-		{% endif %} #}
-
+		{% endfor %}
 
 	{% endcall %}
 {% endblock %}

--- a/app/views/2a/v2/fei/info-needed--details.html
+++ b/app/views/2a/v2/fei/info-needed--details.html
@@ -20,201 +20,35 @@
 		}
 	}) %}
 
-		{% if data['info-needed'].includes('Health needs') %}
-			{{ govukCheckboxes({
-				idPrefix: 'health-needs',
-				name: 'health-needs',
-				fieldset: {
-					legend: {
-						html: 'Health needs',
-						classes: 'govuk-fieldset__legend--m'
-					}
-				},
-				items: [
-					{
-						html: 'Communication needs',
-						value: 'Communication needs',
-						checked: checked('health-needs','Communication needs')
-					},
-					{
-						html: 'Learning difficulties / disabilities',
-						value: 'Learning difficulties / disabilities',
-						checked: checked('health-needs','Learning difficulties / disabilities')
-					},
-					{
-						html: 'Mobility needs',
-						value: 'Mobility needs',
-						checked: checked('health-needs','Mobility needs')
-					},
-					{
-						html: 'Epilepsy',
-						value: 'Epilepsy',
-						checked: checked('health-needs','Epilepsy')
-					},
-					{
-						html: 'Other',
-						value: 'Other',
-						checked: checked('health-needs','Other')
-					}
-				]
-			}) }}
-		{% endif %}
+		{% for category, subcategories in riskCategories() %}
+			{% if data['info-needed'].includes(category) %}
+				{% set items = [] %}
+				{% for subcategory, info_types in subcategories %}
+					{% set items = items | push({
+						html: subcategory,
+						value: subcategory,
+						checked: checked(slugify(category), subcategory)
+					}) %}
+				{% endfor %}
+				{% set items = items | push({
+					html: 'Other',
+					value: 'Other',
+					checked: checked(slugify(category), 'Other')
+				}) %}
 
-		{% if data['info-needed'].includes('Risk to self') %}
-			{{ govukCheckboxes({
-				idPrefix: 'risk-to-self',
-				name: 'risk-to-self',
-				fieldset: {
-					legend: {
-						html: 'Risk to self',
-						classes: 'govuk-fieldset__legend--m'
-					}
-				},
-				items: [
-					{
-						html: 'Substance or alcohol abuse',
-						value: 'Substance or alcohol abuse',
-						checked: checked('risk-to-self','Substance or alcohol abuse')
+				{{ govukCheckboxes({
+					idPrefix: slugify(category),
+					name: slugify(category),
+					fieldset: {
+						legend: {
+							html: category,
+							classes: 'govuk-fieldset__legend--m'
+						}
 					},
-					{
-						html: 'Mental health',
-						value: 'Mental health',
-						checked: checked('risk-to-self','Mental health')
-					},
-					{
-						html: 'Self-harm and suicide',
-						value: 'Self-harm and suicide',
-						checked: checked('risk-to-self','Self-harm and suicide')
-					},
-					{
-						html: 'Vulnerability from others',
-						value: 'Vulnerability from others',
-						checked: checked('risk-to-self','Vulnerability from others')
-					},
-					{
-						html: 'Exploitation (risk to self)',
-						value: 'Exploitation (risk to self)',
-						checked: checked('risk-to-self','Exploitation (risk to self)')
-					},
-					{
-						html: 'Domestic violence (victim)',
-						value: 'Domestic violence (victim)',
-						checked: checked('risk-to-self','Domestic violence (victim)')
-					},
-					{
-						html: 'Sex work',
-						value: 'Sex work',
-						checked: checked('risk-to-self','Sex work')
-					},
-					{
-						html: 'Media interest',
-						value: 'Media interest',
-						checked: checked('risk-to-self','Media interest')
-					},
-					{
-						html: 'Isolation',
-						value: 'Isolation',
-						checked: checked('risk-to-self','Isolation')
-					}
-				]
-			}) }}
-		{% endif %}
-
-
-		{% if data['info-needed'].includes('Risk of serious harm') %}
-			{{ govukCheckboxes({
-				idPrefix: 'risk-of-serious-harm',
-				name: 'risk-of-serious-harm',
-				fieldset: {
-					legend: {
-						html: 'Risk of serious harm',
-						classes: 'govuk-fieldset__legend--m'
-					}
-				},
-				items: [
-					{
-						html: 'Exploitation (risk to others)',
-						value: 'Exploitation (risk to others)',
-						checked: checked('risk-of-serious-harm','Exploitation (risk to others)')
-					},
-					{
-						html: 'Domestic violence (perpatrator)',
-						value: 'Domestic violence (perpatrator)',
-						checked: checked('risk-of-serious-harm','Domestic violence (perpatrator)')
-					},
-					{
-						html: 'Gang involvement',
-						value: 'Gang involvement',
-						checked: checked('risk-of-serious-harm','Gang involvement')
-					},
-					{
-						html: 'Violent offences',
-						value: 'Violent offences',
-						checked: checked('risk-of-serious-harm','Violent offences')
-					},
-					{
-						html: 'Hate-related attitudes',
-						value: 'Hate-related attitudes',
-						checked: checked('risk-of-serious-harm','Hate-related attitudes')
-					},
-					{
-						html: 'Drug supply offences',
-						value: 'Drug supply offences',
-						checked: checked('risk-of-serious-harm','Drug supply offences')
-					},
-					{
-						html: 'County lines involvement',
-						value: 'County lines involvement',
-						checked: checked('risk-of-serious-harm','County lines involvement')
-					},
-					{
-						html: 'Acquisitive offending',
-						value: 'Acquisitive offending',
-						checked: checked('risk-of-serious-harm','Acquisitive offending')
-					},
-					{
-						html: 'Cuckooing',
-						value: 'Cuckooing',
-						checked: checked('risk-of-serious-harm','Cuckooing')
-					},
-					{
-						html: 'Financial abuse or fraud',
-						value: 'Financial abuse or fraud',
-						checked: checked('risk-of-serious-harm','Financial abuse or fraud')
-					},
-					{
-						html: 'Arson offences',
-						value: 'Arson offences',
-						checked: checked('risk-of-serious-harm','Arson offences')
-					},
-					{
-						html: 'Weapons offences',
-						value: 'Weapons offences',
-						checked: checked('risk-of-serious-harm','Weapons offences')
-					},
-					{
-						html: 'Driving offences',
-						value: 'Driving offences',
-						checked: checked('risk-of-serious-harm','Driving offences')
-					},
-					{
-						html: 'Risk to staff',
-						value: 'Risk to staff',
-						checked: checked('risk-of-serious-harm','Risk to staff')
-					},
-					{
-						html: 'Risk to property / criminal damage',
-						value: 'Risk to property / criminal damage',
-						checked: checked('risk-of-serious-harm','Risk to property / criminal damage')
-					},
-					{
-						html: 'Other',
-						value: 'Other',
-						checked: checked('risk-of-serious-harm','Other')
-					}
-				]
-			}) }}
-		{% endif %}
+					items: items
+				}) }}
+			{% endif %}
+		{% endfor %}
 	{% endcall %}
 {% endblock %}
 


### PR DESCRIPTION
This commit adds our current list of risk categories, subcategories, info types and specific persons in a structured format, and updates the prototype pages to be driven from this new data. This fleshes out all of the categories and also makes future changes easier.