### PR TITLE
Updates from testing

### DIFF
--- a/app/data/risks.js
+++ b/app/data/risks.js
@@ -44,14 +44,14 @@ const riskCategories = {
 			"Referral for community support": {},
 		},
 		"Exploitation (risk to self)": {
-			"Known perpatrator(s)": {},
+			"Known perpetrator(s)": {},
 			"Nature of exploitation": {},
 			"Safeguarding measures / restraining orders": {},
 			"Areas to avoid": {},
 
 		},
 		"Domestic violence (victim)": {
-			"Known perpatrator(s)": {},
+			"Known perpetrator(s)": {},
 			"Details of incidents": {},
 			"Safeguarding measures / restraining orders": {},
 			"Areas to avoid": {},
@@ -85,7 +85,7 @@ const riskCategories = {
 			'Safeguarding measures / Restraining orders': {},
 			'Areas to avoid': {},
 		},
-		'Domestic violence (perpatrator)': {
+		'Domestic violence (perpetrator)': {
 			'Specific risk to others': {
 				'Known victim(s)': {},
 				'Ex- or future partners': {},

--- a/app/data/risks.js
+++ b/app/data/risks.js
@@ -19,7 +19,8 @@ const riskCategories = {
 			'Frequency / recency of seizures': {},
 			'When seizures typically occur (day, night, both)': {},
 			'Medication / treatment': {},
-		}
+		},
+		'Other': {},
 	},
 	'Risk to self': {
 		"Substance or alcohol abuse": {
@@ -67,12 +68,7 @@ const riskCategories = {
 			"Current concerns": {},
 			"Areas to avoid": {},
 		},
-		"Isolation": {
-			"Current concerns": {},
-			"Safeguarding measures / restraining orders": {},
-			"Areas to avoid": {},
-			"Support they have / will require": {},
-		}
+		'Other': {},
 	},
 	'Risk of serious harm': {
 		'Exploitation (risk to others)': {
@@ -215,6 +211,7 @@ const riskCategories = {
 			"Details of incidents": {},
 			"If incidents occurred in supported accomodation": {},
 		},
+		'Other': {},
 	}
 }
 

--- a/app/views/2a/index.html
+++ b/app/views/2a/index.html
@@ -16,14 +16,31 @@
 			}) }}
 			<hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
 
+			{% set version = "3" %}
+			<h2 class="govuk-heading-m">
+				Variant {{version}}
+				{{ govukTag({
+					classes: 'govuk-tag--orange govuk-!-margin-left-2',
+					text: 'Ready for review'
+				}) }}
+			</h2>
+
+			<p>Replaced inline Further Information notes for each detailed piece of information with one box to cover the entirety of each risk category, and clarified that this is optional.</p>
+			<p>Removed "Isolation" from the list of risk categories because none of the users recognised it as a valid category.</p>
+			<p>All of the users highlighted the need for the Dashboard view to show all of the details entered, so we now show the full details of the FIE in the timeline.</p>
+
+			{{ govukButton({
+				text: 'View prototype',
+				href: 'v'+version+'/dashboard'
+			}) }}
 
 
 			{% set version = "2" %}
 			<h2 class="govuk-heading-m">
 				Variant {{version}}
 				{{ govukTag({
-					classes: 'govuk-tag--orange govuk-!-margin-left-2',
-					text: 'Ready for review'
+					classes: 'govuk-tag--green govuk-!-margin-left-2',
+					text: 'Researched'
 				}) }}
 			</h2>
 
@@ -40,8 +57,8 @@
 			<h2 class="govuk-heading-m">
 				Variant {{version}}
 				{{ govukTag({
-					classes: 'govuk-tag--blue govuk-!-margin-left-2',
-					text: 'Reviewed'
+					classes: 'govuk-tag--green govuk-!-margin-left-2',
+					text: 'Researched'
 				}) }}
 			</h2>
 
@@ -57,4 +74,3 @@
 		</div>
 	</div>
 {% endblock %}
-

--- a/app/views/2a/index.html
+++ b/app/views/2a/index.html
@@ -28,6 +28,7 @@
 			<p>Replaced inline Further Information notes for each detailed piece of information with one box to cover the entirety of each risk category, and clarified that this is optional.</p>
 			<p>Removed "Isolation" from the list of risk categories because none of the users recognised it as a valid category.</p>
 			<p>All of the users highlighted the need for the Dashboard view to show all of the details entered, so we now show the full details of the FIE in the timeline.</p>
+			<p>Show what is included in the health needs and risk to self categories, as some users struggle to choose between these.</p>
 
 			{{ govukButton({
 				text: 'View prototype',

--- a/app/views/2a/v2/rejection/ineligible.html
+++ b/app/views/2a/v2/rejection/ineligible.html
@@ -89,7 +89,7 @@
 		'Arson',
 		'Communication needs',
 		'Cuckooing',
-		'Domestic violence (perpatrator)',
+		'Domestic violence (perpetrator)',
 		'Domestic violence (victim)',
 		'Driving offences',
 		'Drug supply offences',

--- a/app/views/2a/v2/rejection/suitable-property.html
+++ b/app/views/2a/v2/rejection/suitable-property.html
@@ -50,7 +50,7 @@
 		'Arson',
 		'Communication needs',
 		'Cuckooing',
-		'Domestic violence (perpatrator)',
+		'Domestic violence (perpetrator)',
 		'Domestic violence (victim)',
 		'Driving offences',
 		'Drug supply offences',

--- a/app/views/2a/v3/_routes.js
+++ b/app/views/2a/v3/_routes.js
@@ -33,7 +33,6 @@ router.post('/fei/info-needed', (req, res, next) => {
 })
 
 router.post('/fei/info-needed--details', (req, res, next) => {
-	console.log(req.session.data)
 	const hasContext = Object.keys(riskCategories).find(category => {
 		const slug = category.toLowerCase().replaceAll(/\W/g, '-')
 		const question = req.session.data[slug];

--- a/app/views/2a/v3/_routes.js
+++ b/app/views/2a/v3/_routes.js
@@ -33,6 +33,7 @@ router.post('/fei/info-needed', (req, res, next) => {
 })
 
 router.post('/fei/info-needed--details', (req, res, next) => {
+	console.log(req.session.data)
 	const hasContext = Object.keys(riskCategories).find(category => {
 		const slug = category.toLowerCase().replaceAll(/\W/g, '-')
 		const question = req.session.data[slug];

--- a/app/views/2a/v3/dashboard.html
+++ b/app/views/2a/v3/dashboard.html
@@ -57,6 +57,7 @@
 
 			{%- from "moj/components/timeline/macro.njk" import mojTimeline -%}
 
+			{% if data['status'] == 'More information requested' %}
 			{% set statusHtml -%}
 				{% for category in data['info-needed'] %}
 					{% for subcategory in data[slugify(category)] %}
@@ -77,6 +78,26 @@
 					{% endfor %}
 				{% endfor %}
 			{%- endset %}
+			{% endif %}
+
+			{% if data['status'] == 'Referral cancelled' %}
+			{% set statusHtml -%}
+				<ul class="govuk-list govuk-body-s">
+				{% for criteria in data['ineligibility-unmet'] %}
+					<li>Ineligible: {{ criteria }}</li>
+				{% endfor %}
+				{% for category, subcategories in riskCategories() %}
+					{% if data['unmanageable-' + slugify(category)] %}
+						{% for subcategory in data['unmanageable-' + slugify(category)] %}
+							<li>{{ category }}: {{ subcategory }}</li>
+						{% endfor %}
+					{% endif %}
+				{% endfor %}
+					<li>Why the risk is unmanageable: {{ data['unmanageable-reason'] }}</li>
+					<li>What could change to make the risk manageable: {{ data['unmanageable-change'] }}</li>
+				</ul>
+			{%- endset %}
+			{% endif %}
 
 			{{ mojTimeline({
 				items: [

--- a/app/views/2a/v3/dashboard.html
+++ b/app/views/2a/v3/dashboard.html
@@ -1,0 +1,113 @@
+{% extends "layouts/main.html" %}
+
+{% set title = 'Aadland Bertrand' %}
+
+
+{% block content %}
+	<div class="govuk-grid-row">
+		<div class="govuk-grid-column-full">
+
+			<div class="moj-page-header-actions govuk-!-margin-bottom-2">
+				<div class="moj-page-header-actions__title">
+					<h1 class="govuk-heading-xl">{{title}}</h1>
+				</div>
+
+				<div class="moj-page-header-actions__actions">
+					<div class="moj-button-group moj-button-group--inline">
+
+						<button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button">
+							Download as a PDF
+						</button>
+
+						<button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button">
+							Change assessment details
+						</button>
+
+					</div>
+				</div>
+
+			</div>
+
+			<div class="status-box govuk-!-margin-bottom-5">
+				<p class="govuk-!-display-inline">Current status:
+					<strong class="govuk-tag--blue status-box-tag">
+						{{ data['status']  or 'Received' }}
+					</strong>
+				</p>
+			</div>
+
+			<p>This application was submitted on <strong>8 January 2025</strong>.</p>
+			<p>CAS-2 reference number: <strong>12345</strong>.</p>
+			<p>Assessor name: <strong>John Doe</strong>.</p>
+
+			<div class="govuk-button-group">
+				{{ govukButton({
+					text: 'View submitted application',
+					href: '#0'
+				}) }}
+
+				{{ govukButton({
+					text: 'Update application status',
+					classes: 'govuk-button--secondary',
+					href: 'status'
+				}) }}
+			</div>
+
+			<hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
+
+			{%- from "moj/components/timeline/macro.njk" import mojTimeline -%}
+
+			{% set statusHtml -%}
+				{% for category in data['info-needed'] %}
+					{% for subcategory in data[slugify(category)] %}
+						<h5 class="govuk-heading-xs">{{ category }}: {{ subcategory }}</h5>
+						<ul class="govuk-list govuk-body-s">
+						{% for info_type in data[slugify(subcategory)] %}
+							<li>
+								{{ info_type }}
+								{%- if data[[slugify(subcategory), slugify(info_type)].join('-')] -%}
+									: {{ data[[slugify(subcategory), slugify(info_type)].join('-')].join(', ') }}
+								{% endif %}
+							</li>
+						{% endfor %}
+						{% if data[slugify(subcategory) + '-notes'] %}
+							<li>{{ data[slugify(subcategory) + '-notes'] }}</li>
+						{% endif %}
+						</ul>
+					{% endfor %}
+				{% endfor %}
+			{%- endset %}
+
+			{{ mojTimeline({
+				items: [
+					{
+						label: {
+							text:  data['status']
+						},
+						html: statusHtml,
+						datetime: {
+							timestamp: "2025-01-01T13:15:00.000Z",
+							type: "datetime"
+						},
+						byline: {
+							text: "Joe Bloggs"
+						}
+					} if data['status'],
+					{
+						label: {
+							text:  "Application submitted"
+						},
+						datetime: {
+							timestamp: "2025-01-01T13:15:00.000Z",
+							type: "datetime"
+						},
+						byline: {
+							text: "Joe Bloggs"
+						}
+					}
+				] | cleanArray
+			}) }}
+
+		</div>
+	</div>
+{% endblock %}

--- a/app/views/2a/v3/fei/info-needed--context.html
+++ b/app/views/2a/v3/fei/info-needed--context.html
@@ -1,0 +1,98 @@
+{% extends "layouts/main.html" %}
+
+{% set title = 'What information is missing or insufficient?' %}
+
+
+{% block questions %}
+	<div class="status-box govuk-!-margin-bottom-5">
+		<p class="govuk-!-display-inline">Current status:
+			<strong class="govuk-tag--blue status-box-tag">
+				Received
+			</strong>
+		</p>
+	</div>
+
+	{% macro noteBox(idPrefix) %}
+		{{ govukTextarea({
+			name: [idPrefix, 'notes'].join('-'),
+			id: [idPrefix, 'notes'].join('-'),
+			rows: 3,
+			label: {
+				html: 'Add any extra notes for the referrer',
+				classes: 'govuk-label--s'
+			}
+		}) }}
+	{% endmacro -%}
+
+	{% call govukFieldset({
+		legend: {
+		html: title,
+		classes: 'govuk-fieldset__legend--l',
+		isPageHeading: true
+		}
+	}) %}
+
+		{% for category, subcategories in riskCategories() %}
+			{% if data[slugify(category)] %}
+				{% for subcategory, info_types in subcategories %}
+					{% if data[slugify(category)].includes(subcategory) %}
+						{% set items = [] %}
+						{% for info_type, details in info_types %}
+							{% set conditional = "" %}
+							{% set detail_length = details | length %}
+							{% if detail_length > 0 %}
+								{% set more = [] %}
+								{% for detail, empty in details %}
+									{% set more = more | push({
+										html: detail,
+										value: detail
+									}) %}
+								{% endfor %}
+								{% set conditional = govukCheckboxes({
+									idPrefix: [slugify(subcategory), slugify(info_type)].join('-'),
+									name: [slugify(subcategory), slugify(info_type)].join('-'),
+									items: more
+								}) %}
+							{% endif %}
+
+							{% set items = items | push({
+								html: info_type,
+								value: info_type,
+								checked: checked(slugify(subcategory), info_type),
+								conditional: {
+									html: conditional
+								}
+							}) %}
+						{% endfor %}
+
+						{{ govukCheckboxes({
+							idPrefix: slugify(subcategory),
+							name: slugify(subcategory),
+							fieldset: {
+								legend: {
+									html: subcategory,
+									classes: 'govuk-fieldset__legend--m'
+								}
+							},
+							formGroup: {
+								afterInputs: {html: noteBox(slugify(subcategory)) }
+							},
+							items: items
+						}) }}
+					{% endif %}
+				{% endfor %}
+			{% endif %}
+		{% endfor %}
+
+	{% endcall %}
+{% endblock %}
+
+{% block buttons %}
+	<div class="govuk-button-group">
+		{{ govukButton({
+			text: 'Save and continue'
+		}) }}
+
+		<a class="govuk-link" href="#0">Back to application overview</a>
+	</div>
+{% endblock %}

--- a/app/views/2a/v3/fei/info-needed--details.html
+++ b/app/views/2a/v3/fei/info-needed--details.html
@@ -1,0 +1,58 @@
+{% extends "layouts/main.html" %}
+
+{% set title = 'Where is more information required?' %}
+
+
+{% block questions %}
+	<div class="status-box govuk-!-margin-bottom-5">
+		<p class="govuk-!-display-inline">Current status:
+			<strong class="govuk-tag--blue status-box-tag">
+				Received
+			</strong>
+		</p>
+	</div>
+
+	{% call govukFieldset({
+		legend: {
+		html: title,
+		classes: 'govuk-fieldset__legend--l',
+		isPageHeading: true
+		}
+	}) %}
+
+		{% for category, subcategories in riskCategories() %}
+			{% if data['info-needed'].includes(category) %}
+				{% set items = [] %}
+				{% for subcategory, info_types in subcategories %}
+					{% set items = items | push({
+						html: subcategory,
+						value: subcategory,
+						checked: checked(slugify(category), subcategory)
+					}) %}
+				{% endfor %}
+
+				{{ govukCheckboxes({
+					idPrefix: slugify(category),
+					name: slugify(category),
+					fieldset: {
+						legend: {
+							html: category,
+							classes: 'govuk-fieldset__legend--m'
+						}
+					},
+					items: items
+				}) }}
+			{% endif %}
+		{% endfor %}
+	{% endcall %}
+{% endblock %}
+
+{% block buttons %}
+	<div class="govuk-button-group">
+		{{ govukButton({
+			text: 'Save and continue'
+		}) }}
+
+		<a class="govuk-link" href="#0">Back to application overview</a>
+	</div>
+{% endblock %}

--- a/app/views/2a/v3/fei/info-needed.html
+++ b/app/views/2a/v3/fei/info-needed.html
@@ -1,0 +1,84 @@
+{% extends "layouts/main.html" %}
+
+{% set title = 'What information do you need?' %}
+
+
+{% block questions %}
+	<div class="status-box govuk-!-margin-bottom-5">
+		<p class="govuk-!-display-inline">Current status:
+			<strong class="govuk-tag--blue status-box-tag">
+				Received
+			</strong>
+		</p>
+	</div>
+
+	{{ govukCheckboxes({
+		idPrefix: 'info-needed',
+		name: 'info-needed',
+		fieldset: {
+			legend: {
+				html: title,
+				classes: 'govuk-fieldset__legend--l',
+				isPageHeading: true
+			}
+		},
+		items: [
+			{
+				html: 'Personal information',
+				value: 'Personal information',
+				checked: checked('info-needed','Personal information')
+			},
+			{
+				html: 'Exclusion zones and preferred areas',
+				value: 'Exclusion zones and preferred areas',
+				checked: checked('info-needed','Exclusion zones and preferred areas')
+			},
+			{
+				html: 'Health needs',
+				value: 'Health needs',
+				checked: checked('info-needed','Health needs')
+			},
+			{
+				html: 'Risk to self',
+				value: 'Risk to self',
+				checked: checked('info-needed','Risk to self')
+			},
+			{
+				html: 'Risk of serious harm',
+				value: 'Risk of serious harm',
+				checked: checked('info-needed','Risk of serious harm')
+			},
+			{
+				html: 'Current offences',
+				value: 'Current offences',
+				checked: checked('info-needed','Current offences')
+			},
+			{
+				html: 'Offending history',
+				value: 'Offending history',
+				checked: checked('info-needed','Offending history')
+			},
+			{
+				html: 'HDC licence and CPP details',
+				value: 'HDC licence and CPP details',
+				checked: checked('info-needed','HDC licence and CPP details')
+			},
+			{
+				html: 'Other',
+				value: 'Other',
+				checked: checked('info-needed','Other')
+			}
+		]
+	}) }}
+{% endblock %}
+
+
+{% block buttons %}
+	<div class="govuk-button-group">
+		{{ govukButton({
+			text: 'Save and continue'
+		}) }}
+
+		<a class="govuk-link" href="#0">Back to application overview</a>
+	</div>
+{% endblock %}

--- a/app/views/2a/v3/fei/info-needed.html
+++ b/app/views/2a/v3/fei/info-needed.html
@@ -12,6 +12,18 @@
 		</p>
 	</div>
 
+	{% macro getSubcategories(category) -%}
+		{%- set comma = joiner(', ') -%}
+		{%- for subcategory, info_type in riskCategories()[category] -%}
+			{%- if subcategory !== 'Other' -%}
+			{{ comma() }}{{ subcategory | lower }}
+			{%- endif -%}
+		{%- endfor -%}
+	{%- endmacro %}
+
+	{% set healthSubcategories %}{{ getSubcategories('Health needs') }}{% endset %}
+	{% set riskToSelfSubcategories %}{{ getSubcategories('Risk to self') }}{% endset %}
+
 	{{ govukCheckboxes({
 		idPrefix: 'info-needed',
 		name: 'info-needed',
@@ -36,11 +48,17 @@
 			{
 				html: 'Health needs',
 				value: 'Health needs',
+				hint: {
+					text: "Including " + healthSubcategories + "."
+				},
 				checked: checked('info-needed','Health needs')
 			},
 			{
 				html: 'Risk to self',
 				value: 'Risk to self',
+				hint: {
+					text: "Including " + riskToSelfSubcategories + "."
+				},
 				checked: checked('info-needed','Risk to self')
 			},
 			{

--- a/app/views/2a/v3/fei/note.html
+++ b/app/views/2a/v3/fei/note.html
@@ -1,0 +1,40 @@
+{% extends "layouts/main.html" %}
+
+{% set title = 'Add a note for the referrer' %}
+
+
+{% block questions %}
+	<div class="status-box govuk-!-margin-bottom-5">
+		<p class="govuk-!-display-inline">Current status:
+			<strong class="govuk-tag--blue status-box-tag">
+				Received
+			</strong>
+		</p>
+	</div>
+
+	{{ govukTextarea({
+		name: 'note',
+		id: 'note',
+		value: data['note'],
+		rows: '5',
+		label: {
+			html: title,
+			classes: 'govuk-label--l',
+			isPageHeading: true
+		},
+		hint: {
+			html: ''
+		}
+	}) }}
+{% endblock %}
+
+
+{% block buttons %}
+	<div class="govuk-button-group">
+		{{ govukButton({
+			text: 'Save and continue'
+		}) }}
+
+		<a class="govuk-link" href="#0">Back to application overview</a>
+	</div>
+{% endblock %}

--- a/app/views/2a/v3/rejection/area-unsuitable--transport.html
+++ b/app/views/2a/v3/rejection/area-unsuitable--transport.html
@@ -1,0 +1,68 @@
+{% extends "layouts/main.html" %}
+
+{% set title = 'Unsuitable transport time and cost details' %}
+
+
+{% block questions %}
+	<div class="status-box govuk-!-margin-bottom-5">
+		<p class="govuk-!-display-inline">Current status:
+			<strong class="govuk-tag--blue status-box-tag">
+				Received
+			</strong>
+		</p>
+	</div>
+
+	{% call govukFieldset({
+		legend: {
+		html: title,
+		classes: 'govuk-fieldset__legend--l',
+		isPageHeading: true
+		}
+	}) %}
+
+		{{ govukInput({
+			id: 'transport-time',
+			name: 'transport-time',
+			value: data['transport-time'],
+			classes: 'govuk-input--width-4',
+			label: {
+				html: 'What is maximum transport time they\'d accept?',
+				classes: 'govuk-label--m'
+			}
+		}) }}
+
+		{{ govukRadios({
+			idPrefix: 'transport-services',
+			name: 'transport-services',
+			fieldset: {
+				legend: {
+					html: 'Are they aware of CAS-2 transport services?',
+					classes: 'govuk-fieldset__legend--m'
+				}
+			},
+			items: [
+				{
+					html: 'Yes',
+					value: 'Yes',
+					checked: checked('transport-services','Yes')
+				},
+				{
+					html: 'No',
+					value: 'No',
+					checked: checked('transport-services','No')
+				}
+			]
+		}) }}
+
+	{% endcall %}
+{% endblock %}
+
+{% block buttons %}
+	<div class="govuk-button-group">
+		{{ govukButton({
+			text: 'Save and continue'
+		}) }}
+
+		<a class="govuk-link" href="#0">Back to application overview</a>
+	</div>
+{% endblock %}

--- a/app/views/2a/v3/rejection/area-unsuitable.html
+++ b/app/views/2a/v3/rejection/area-unsuitable.html
@@ -1,0 +1,48 @@
+{% extends "layouts/main.html" %}
+
+{% set title = 'What made the area unsuitable?' %}
+
+
+{% block questions %}
+	<div class="status-box govuk-!-margin-bottom-5">
+		<p class="govuk-!-display-inline">Current status:
+			<strong class="govuk-tag--blue status-box-tag">
+				Received
+			</strong>
+		</p>
+	</div>
+
+	{% set list = ['Transport time / cost',
+	'Risk to applicant in that area',
+	'Other'] %}
+	{% set options = [] %}
+	{% for i in list %}
+		{% set options = options | push ({
+			'html': i,
+			'value': i,
+			'checked': checked('unsuitable-area',i)
+		}) %}
+	{% endfor %}
+	{{ govukCheckboxes({
+		idPrefix: 'unsuitable-area',
+		name: 'unsuitable-area',
+		fieldset: {
+			legend: {
+				html: title,
+				classes: 'govuk-fieldset__legend--l',
+				isPageHeading: true
+			}
+		},
+		items: options
+	}) }}
+{% endblock %}
+
+{% block buttons %}
+	<div class="govuk-button-group">
+		{{ govukButton({
+			text: 'Save and continue'
+		}) }}
+
+		<a class="govuk-link" href="#0">Back to application overview</a>
+	</div>
+{% endblock %}

--- a/app/views/2a/v3/rejection/circumstances.html
+++ b/app/views/2a/v3/rejection/circumstances.html
@@ -1,0 +1,63 @@
+{% extends "layouts/main.html" %}
+
+{% set title = 'How have the circumstances changed?' %}
+
+
+{% block questions %}
+	<div class="status-box govuk-!-margin-bottom-5">
+		<p class="govuk-!-display-inline">Current status:
+			<strong class="govuk-tag--blue status-box-tag">
+				Received
+			</strong>
+		</p>
+	</div>
+
+	{% set other %}
+		{{ govukTextarea({
+			name: 'circumstances-details',
+			id: 'circumstances-details',
+			value: data['circumstances-details'],
+			rows: 2,
+			label: {
+				html: 'Details',
+				classes: 'govuk-label--s'
+			}
+		}) }}
+	{% endset -%}
+	{{ govukRadios({
+		idPrefix: 'circumstances',
+		name: 'circumstances',
+		fieldset: {
+			legend: {
+				html: title,
+				classes: 'govuk-fieldset__legend--l',
+				isPageHeading: true
+			}
+		},
+		items: [
+			{
+				html: 'Own bail accomodation became available',
+				value: 'Own bail accomodation became available',
+				checked: checked('circumstances','Own bail accomodation became available')
+			},
+			{
+				html: 'Other',
+				value: 'Other',
+				checked: checked('circumstances','Other'),
+				conditional: {
+					html: other
+				}
+			}
+		]
+	}) }}
+{% endblock %}
+
+{% block buttons %}
+	<div class="govuk-button-group">
+		{{ govukButton({
+			text: 'Save and continue'
+		}) }}
+
+		<a class="govuk-link" href="#0">Back to application overview</a>
+	</div>
+{% endblock %}

--- a/app/views/2a/v3/rejection/ineligible.html
+++ b/app/views/2a/v3/rejection/ineligible.html
@@ -20,45 +20,6 @@
 		}
 	}) %}
 
-		{% set moreSupport %}
-			{{ govukTextarea({
-				name: 'more-support',
-				id: 'more-support',
-				value: data['more-support'],
-				rows: 2,
-				label: {
-					html: 'What extra support would have been needed?',
-					classes: 'govuk-label--s'
-				}
-			}) }}
-		{% endset -%}
-		{{ govukRadios({
-			idPrefix: 'ineligibility-permanence',
-			name: 'ineligibility-permanence',
-			fieldset: {
-				legend: {
-					html: 'Is ineligibility permanent or circumstantial?',
-					classes: 'govuk-fieldset__legend--m'
-				}
-			},
-			items: [
-				{
-					html: 'Applicant would always be ineligible',
-					value: 'Applicant would always be ineligible',
-					checked: checked('ineligibility-permanence','Applicant would always be ineligible')
-				},
-				{
-					html: 'Applicant may be eligible if more support was available',
-					value: 'Applicant may be eligible if more support was available',
-					checked: checked('ineligibility-permanence','Applicant may be eligible if more support was available'),
-					conditional: {
-						html: moreSupport
-					}
-				}
-			]
-		}) }}
-
-
 		{% set list = ['Sexual offences',
 		'Age',
 		'High risk of serious harm',
@@ -84,41 +45,21 @@
 			items: options
 		}) }}
 
+	{% call govukFieldset({
+		legend: {
+		text: 'What risk is unmanagable?',
+		classes: 'govuk-fieldset__legend--m',
+		isPageHeading: true
+		}
+	}) %}
 
-		{% set list = ['Acquisitive offending',
-		'Arson',
-		'Communication needs',
-		'Cuckooing',
-		'Domestic violence (perpetrator)',
-		'Domestic violence (victim)',
-		'Driving offences',
-		'Drug supply offences',
-		'Epilepsy',
-		'Exploitation (risk to others)',
-		'Exploitation (risk to self)',
-		'Financial abuse or fraud',
-		'Gang involvement',
-		'Hate-related attitudes',
-		'Isolation',
-		'Learning difficulties / disabilities',
-		'Media/public interest',
-		'Mental health',
-		'Mobility needs',
-		'Other ',
-		'Other vulnerability',
-		'Risk to property / criminal damage',
-		'Risk to staff',
-		'Self-harm and suicide',
-		'Sex work',
-		'Substance or alcohol abuse',
-		'Violent offences',
-		'Weapons'] %}
+	{% for category, subcategories in riskCategories() %}
 		{% set options = [] %}
-		{% for i in list %}
+		{% for subcategory, info_type in subcategories %}
 			{% set options = options | push ({
-				'html': i,
-				'value': i,
-				'checked': checked('unmanagable',i)
+				'html': subcategory,
+				'value': slugify(subcategory),
+				'checked': checked('unmanagable',slugify(subcategory))
 			}) %}
 		{% endfor %}
 		{{ govukCheckboxes({
@@ -126,22 +67,36 @@
 			name: 'unmanagable',
 			fieldset: {
 				legend: {
-					html: 'What risk is unmanagable?',
-					classes: 'govuk-fieldset__legend--m'
+					text: category,
+					classes: 'govuk-fieldset__legend--s'
 				}
 			},
 			items: options
 		}) }}
+	{% endfor %}
 
-		{{ govukTextarea({
-			name: 'unmanageable-reason',
-			id: 'unmanageable-reason',
-			value: data['unmanageable-reason'],
-			label: {
-				html: 'Why is this risk unmanagable?',
-				classes: 'govuk-label--m'
-			}
-		}) }}
+	{{ govukTextarea({
+		name: 'unmanageable-reason',
+		id: 'unmanageable-reason',
+		value: data['unmanageable-reason'],
+		rows: 3,
+		label: {
+			html: 'Why is this risk unmanageable?',
+			classes: 'govuk-label--m'
+		}
+	}) }}
+
+	{{ govukTextarea({
+		name: 'unmanageable-change',
+		id: 'unmanageable-change',
+		value: data['unmanageable-change'],
+		rows: 3,
+		label: {
+			html: 'What would need to change for the risk to be manageable?',
+			classes: 'govuk-label--m'
+		}
+	}) }}
+	{% endcall %}
 
 	{% endcall %}
 {% endblock %}

--- a/app/views/2a/v3/rejection/ineligible.html
+++ b/app/views/2a/v3/rejection/ineligible.html
@@ -1,0 +1,157 @@
+{% extends "layouts/main.html" %}
+
+{% set title = 'Details of risk or ineligibility' %}
+
+
+{% block questions %}
+	<div class="status-box govuk-!-margin-bottom-5">
+		<p class="govuk-!-display-inline">Current status:
+			<strong class="govuk-tag--blue status-box-tag">
+				Received
+			</strong>
+		</p>
+	</div>
+
+	{% call govukFieldset({
+		legend: {
+		html: title,
+		classes: 'govuk-fieldset__legend--l',
+		isPageHeading: true
+		}
+	}) %}
+
+		{% set moreSupport %}
+			{{ govukTextarea({
+				name: 'more-support',
+				id: 'more-support',
+				value: data['more-support'],
+				rows: 2,
+				label: {
+					html: 'What extra support would have been needed?',
+					classes: 'govuk-label--s'
+				}
+			}) }}
+		{% endset -%}
+		{{ govukRadios({
+			idPrefix: 'ineligibility-permanence',
+			name: 'ineligibility-permanence',
+			fieldset: {
+				legend: {
+					html: 'Is ineligibility permanent or circumstantial?',
+					classes: 'govuk-fieldset__legend--m'
+				}
+			},
+			items: [
+				{
+					html: 'Applicant would always be ineligible',
+					value: 'Applicant would always be ineligible',
+					checked: checked('ineligibility-permanence','Applicant would always be ineligible')
+				},
+				{
+					html: 'Applicant may be eligible if more support was available',
+					value: 'Applicant may be eligible if more support was available',
+					checked: checked('ineligibility-permanence','Applicant may be eligible if more support was available'),
+					conditional: {
+						html: moreSupport
+					}
+				}
+			]
+		}) }}
+
+
+		{% set list = ['Sexual offences',
+		'Age',
+		'High risk of serious harm',
+		'Breaching immigration law',
+		'No route to public funds'] %}
+		{% set options = [] %}
+		{% for i in list %}
+			{% set options = options | push ({
+				'html': i,
+				'value': i,
+				'checked': checked('ineligibility-unmet',i)
+			}) %}
+		{% endfor %}
+		{{ govukCheckboxes({
+			idPrefix: 'ineligibility-unmet',
+			name: 'ineligibility-unmet',
+			fieldset: {
+				legend: {
+					html: 'What eligibility criteria is unmet?',
+					classes: 'govuk-fieldset__legend--m'
+				}
+			},
+			items: options
+		}) }}
+
+
+		{% set list = ['Acquisitive offending',
+		'Arson',
+		'Communication needs',
+		'Cuckooing',
+		'Domestic violence (perpetrator)',
+		'Domestic violence (victim)',
+		'Driving offences',
+		'Drug supply offences',
+		'Epilepsy',
+		'Exploitation (risk to others)',
+		'Exploitation (risk to self)',
+		'Financial abuse or fraud',
+		'Gang involvement',
+		'Hate-related attitudes',
+		'Isolation',
+		'Learning difficulties / disabilities',
+		'Media/public interest',
+		'Mental health',
+		'Mobility needs',
+		'Other ',
+		'Other vulnerability',
+		'Risk to property / criminal damage',
+		'Risk to staff',
+		'Self-harm and suicide',
+		'Sex work',
+		'Substance or alcohol abuse',
+		'Violent offences',
+		'Weapons'] %}
+		{% set options = [] %}
+		{% for i in list %}
+			{% set options = options | push ({
+				'html': i,
+				'value': i,
+				'checked': checked('unmanagable',i)
+			}) %}
+		{% endfor %}
+		{{ govukCheckboxes({
+			idPrefix: 'unmanagable',
+			name: 'unmanagable',
+			fieldset: {
+				legend: {
+					html: 'What risk is unmanagable?',
+					classes: 'govuk-fieldset__legend--m'
+				}
+			},
+			items: options
+		}) }}
+
+		{{ govukTextarea({
+			name: 'unmanageable-reason',
+			id: 'unmanageable-reason',
+			value: data['unmanageable-reason'],
+			label: {
+				html: 'Why is this risk unmanagable?',
+				classes: 'govuk-label--m'
+			}
+		}) }}
+
+	{% endcall %}
+{% endblock %}
+
+{% block buttons %}
+	<div class="govuk-button-group">
+		{{ govukButton({
+			text: 'Save and continue'
+		}) }}
+
+		<a class="govuk-link" href="#0">Back to application overview</a>
+	</div>
+{% endblock %}

--- a/app/views/2a/v3/rejection/ineligible.html
+++ b/app/views/2a/v3/rejection/ineligible.html
@@ -58,13 +58,13 @@
 		{% for subcategory, info_type in subcategories %}
 			{% set options = options | push ({
 				'html': subcategory,
-				'value': slugify(subcategory),
-				'checked': checked('unmanagable',slugify(subcategory))
+				'value': subcategory,
+				'checked': checked('unmanageable', subcategory)
 			}) %}
 		{% endfor %}
 		{{ govukCheckboxes({
-			idPrefix: 'unmanagable',
-			name: 'unmanagable',
+			idPrefix: 'unmanageable-' + slugify(category),
+			name: 'unmanageable-' + slugify(category),
 			fieldset: {
 				legend: {
 					text: category,

--- a/app/views/2a/v3/rejection/reason.html
+++ b/app/views/2a/v3/rejection/reason.html
@@ -1,0 +1,90 @@
+{% extends "layouts/main.html" %}
+
+{% set title = 'Why has the referral been cancelled?' %}
+
+
+{% block questions %}
+	<div class="status-box govuk-!-margin-bottom-5">
+		<p class="govuk-!-display-inline">Current status:
+			<strong class="govuk-tag--blue status-box-tag">
+				Received
+			</strong>
+		</p>
+	</div>
+
+	{% set otherBox %}
+		{{ govukTextarea({
+			name: 'other-details',
+			id: 'other-details',
+			value: data['other-details'],
+			rows: 2,
+			label: {
+				html: 'What is the other reason?',
+				classes: 'govuk-label--s'
+			}
+		}) }}
+	{% endset -%}
+
+	{{ govukRadios({
+		idPrefix: 'reason',
+		name: 'reason',
+		fieldset: {
+			legend: {
+				html: title,
+				classes: 'govuk-fieldset__legend--l',
+				isPageHeading: true
+			}
+		},
+		items: [
+			{
+				html: 'Too high risk / ineligible',
+				value: 'Too high risk / ineligible',
+				checked: checked('reason','Too high risk / ineligible')
+			},
+			{
+				html: 'No suitable property available',
+				value: 'No suitable property available',
+				checked: checked('reason','No suitable property available')
+			},
+			{
+				html: 'No suitable area available',
+				value: 'No suitable area available',
+				checked: checked('reason','No suitable area available')
+			},
+			{
+				html: 'Change of circumstances',
+				value: 'Change of circumstances',
+				checked: checked('reason','Change of circumstances')
+			},
+			{
+				html: 'Transferred to another prison',
+				value: 'Transferred to another prison',
+				checked: checked('reason','Transferred to another prison')
+			},
+			{
+				html: 'Not enough information to assess risk',
+				value: 'Not enough information to assess risk',
+				checked: checked('reason', 'Not enough information to assess risk')
+			},
+			{
+				html: 'Other',
+				value: 'Other',
+				checked: checked('reason', 'Other'),
+				conditional: {
+					html: otherBox
+				}
+			}
+		]
+	}) }}
+{% endblock %}
+
+
+{% block buttons %}
+	<div class="govuk-button-group">
+		{{ govukButton({
+			text: 'Save and continue'
+		}) }}
+
+		<a class="govuk-link" href="#0">Back to application overview</a>
+	</div>
+{% endblock %}

--- a/app/views/2a/v3/rejection/suitable-property.html
+++ b/app/views/2a/v3/rejection/suitable-property.html
@@ -1,0 +1,108 @@
+{% extends "layouts/main.html" %}
+
+{% set title = 'Details of unsuitable property' %}
+
+
+{% block questions %}
+	<div class="status-box govuk-!-margin-bottom-5">
+		<p class="govuk-!-display-inline">Current status:
+			<strong class="govuk-tag--blue status-box-tag">
+				Received
+			</strong>
+		</p>
+	</div>
+
+	{% call govukFieldset({
+		legend: {
+		html: title,
+		classes: 'govuk-fieldset__legend--l',
+		isPageHeading: true
+		}
+	}) %}
+
+		{% set list = ['Applicant\'s gender',
+		'Applicant needed a family unit',
+		'Applicant not managable in that property',
+		'Applicant not compatible with other residents',
+		'Other'] %}
+		{% set options = [] %}
+		{% for i in list %}
+			{% set options = options | push ({
+				'html': i,
+				'value': i,
+				'checked': checked('unsuitable-property',i)
+			}) %}
+		{% endfor %}
+		{{ govukCheckboxes({
+			idPrefix: 'unsuitable-property',
+			name: 'unsuitable-property',
+			fieldset: {
+				legend: {
+					html: 'What made the available properties unsuitable',
+					classes: 'govuk-fieldset__legend--m'
+				}
+			},
+			items: options
+		}) }}
+
+
+		{% set list = ['Acquisitive offending',
+		'Arson',
+		'Communication needs',
+		'Cuckooing',
+		'Domestic violence (perpetrator)',
+		'Domestic violence (victim)',
+		'Driving offences',
+		'Drug supply offences',
+		'Epilepsy',
+		'Exploitation (risk to others)',
+		'Exploitation (risk to self)',
+		'Financial abuse or fraud',
+		'Gang involvement',
+		'Hate-related attitudes',
+		'Isolation',
+		'Learning difficulties / disabilities',
+		'Media/public interest',
+		'Mental health',
+		'Mobility needs',
+		'Other ',
+		'Other vulnerability',
+		'Risk to property / criminal damage',
+		'Risk to staff',
+		'Self-harm and suicide',
+		'Sex work',
+		'Substance or alcohol abuse',
+		'Violent offences',
+		'Weapons'] %}
+		{% set options = [] %}
+		{% for i in list %}
+			{% set options = options | push ({
+				'html': i,
+				'value': i,
+				'checked': checked('unsuitable-risk',i)
+			}) %}
+		{% endfor %}
+		{{ govukCheckboxes({
+			idPrefix: 'unsuitable-risk',
+			name: 'unsuitable-risk',
+			fieldset: {
+				legend: {
+					html: 'What risk from the applicant makes the property unsuitable?',
+					classes: 'govuk-fieldset__legend--m'
+				}
+			},
+			items: options
+		}) }}
+
+	{% endcall %}
+{% endblock %}
+
+{% block buttons %}
+	<div class="govuk-button-group">
+		{{ govukButton({
+			text: 'Save and continue'
+		}) }}
+
+		<a class="govuk-link" href="#0">Back to application overview</a>
+	</div>
+{% endblock %}

--- a/app/views/2a/v3/status.html
+++ b/app/views/2a/v3/status.html
@@ -1,0 +1,84 @@
+{% extends "layouts/main.html" %}
+
+{% set title = 'What is the latest status of Aadland Bertrand\'s application?' %}
+
+
+{% block questions %}
+	<div class="status-box govuk-!-margin-bottom-5">
+		<p class="govuk-!-display-inline">Current status:
+			<strong class="govuk-tag--blue status-box-tag">
+				Received
+			</strong>
+		</p>
+	</div>
+
+	{{ govukRadios({
+		idPrefix: 'status',
+		name: 'status',
+		fieldset: {
+			legend: {
+				html: title,
+				classes: 'govuk-fieldset__legend--l',
+				isPageHeading: true
+			}
+		},
+		items: [
+			{
+				html: 'More information requested',
+				value: 'More information requested',
+				checked: checked('status','More information requested')
+			},
+			{
+				html: 'Awaiting decision',
+				value: 'Awaiting decision',
+				checked: checked('status','Awaiting decision')
+			},
+			{
+				html: 'On waiting list',
+				value: 'On waiting list',
+				checked: checked('status','On waiting list')
+			},
+			{
+				html: 'Place offered',
+				value: 'Place offered',
+				checked: checked('status','Place offered')
+			},
+			{
+				html: 'Offer accepted',
+				value: 'Offer accepted',
+				checked: checked('status','Offer accepted')
+			},
+			{
+				html: 'Offer declined or withdrawn',
+				value: 'Offer declined or withdrawn',
+				checked: checked('status','Offer declined or withdrawn')
+			},
+			{
+				html: 'Referral withdrawn',
+				value: 'Referral withdrawn',
+				checked: checked('status','Referral withdrawn')
+			},
+			{
+				html: 'Referral cancelled',
+				value: 'Referral cancelled',
+				checked: checked('status','Referral cancelled')
+			},
+			{
+				html: 'Awaiting arrival',
+				value: 'Awaiting arrival',
+				checked: checked('status','Awaiting arrival')
+			}
+		]
+	}) }}
+{% endblock %}
+
+
+{% block buttons %}
+	<div class="govuk-button-group">
+		{{ govukButton({
+			text: 'Save and continue'
+		}) }}
+
+		<a class="govuk-link" href="#0">Back to application overview</a>
+	</div>
+{% endblock %}


### PR DESCRIPTION
- Replaced inline Further Information notes for each detailed piece of information with one box to cover the entirety of each risk category, and clarified that this is optional.
- Removed "Isolation" from the list of risk categories because none of the users recognised it as a valid category.
- All of the users highlighted the need for the Dashboard view to show all of the details entered, so we now show the full details in the timeline.
- Show what is included in the health needs and risk to self categories, as some users struggle to choose between these.